### PR TITLE
fix query builder not sorting properly

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -181,7 +181,7 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
 
         if (!$this->hasOffset($offset)) {
-            return ':query FETCH FIRST ' . $limit . ' ROWS ONLY';
+            return ':query :order FETCH FIRST ' . $limit . ' ROWS ONLY';
         }
 
         /**


### PR DESCRIPTION
Hi, in the buildLimit function the :order placeholder is missing